### PR TITLE
Add GitHub actions pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,36 @@ stages:
       jobTitle: 'Build_Functions_Sites_API'
       project_title: $(project_title)
 
+  - job: BuildAllProjects
+    displayName: Build All Projects
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - task: UseDotNet@2
+      displayName: 'Use .NET SDK'
+      inputs:
+        useGlobalJson: false
 
+    - task: DotNetCoreCLI@2
+      displayName: Restore
+      inputs:
+        command: restore
+        projects: '**/*.csproj'
+
+    - task: DotNetCoreCLI@2
+      displayName: Build
+      inputs:
+        command: build
+        projects: '**/*.csproj'
+        arguments: '--configuration Release'
+
+    - task: DotNetCoreCLI@2
+      displayName: Test
+      inputs:
+        command: test
+        projects: '**/*.Tests/*.csproj'
+        arguments: '--configuration Release --collect "code coverage"'
+        publishTestResults: true
 
   # jobs:
   # - job: BuildJob
@@ -87,4 +116,3 @@ stages:
 #       environment: "Dev"
 #       targetJson: "Dev.json"
 #       serviceConnection: "TestProjectsServiceConnection"
-

--- a/build-dotnet-core-package.yml
+++ b/build-dotnet-core-package.yml
@@ -43,7 +43,7 @@ jobs:
     displayName: Test
     inputs:
       command: test
-      projects: 'src/${{ parameters.project_title }}.Tests/*.csproj'
+      projects: '**/*.Tests/*.csproj'
       publishTestResults: true
       arguments: '--configuration $(build_configuration) --collect "code coverage"'
 
@@ -106,4 +106,3 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'
       ArtifactName: Drop
-


### PR DESCRIPTION
Related to #1

Add steps to build all projects and run tests from all .NET test projects in the GitHub actions pipeline.

* Modify `azure-pipelines.yml` to include a new job `BuildAllProjects` that builds and tests all projects in the solution.
* Modify `build-dotnet-core-package.yml` to run tests from all .NET test projects instead of only the `AzureFunctions.Api` project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/12c-dk/DbMigration3/issues/1?shareId=720dd01f-964b-467d-8f17-77fd151090e1).